### PR TITLE
Update SSO utils with ephemcc

### DIFF
--- a/fink_utils/sso/utils.py
+++ b/fink_utils/sso/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022 AstroLab Software
+# Copyright 2022-2023 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import requests
+import os
 
 import pandas as pd
 import numpy as np
@@ -96,7 +97,89 @@ def query_miriade(ident, jd, observer='I41', rplane='1', tcoor=5, shift=15.):
 
     return ephem
 
-def get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=True):
+def query_miriade_epehemcc(ident, jd, observer='I41', rplane='1', tcoor=5, shift=15., parameters={}):
+    """ Gets asteroid or comet ephemerides from IMCCE Miriade for a suite of JD for a single SSO
+
+    This uses local installation of ephemcc instead of the REST API.
+
+    Limitations:
+        - Color ephemerides are returned only for asteroids
+        - Temporary designations (C/... or YYYY...) do not have ephemerides available
+
+    Parameters
+    ----------
+    ident: int, float, str
+        asteroid or comet identifier
+    jd: array
+        dates to query
+    observer: str
+        IAU Obs code - default to ZTF: https://minorplanetcenter.net//iau/lists/ObsCodesF.html
+    rplane: str
+        Reference plane: equator ('1'), ecliptic ('2').
+        If rplane = '2', then tcoor is automatically set to 1 (spherical)
+    tcoor: int
+        See https://ssp.imcce.fr/webservices/miriade/api/ephemcc/
+        Default is 5 (dedicated to observation)
+    shift: float
+        Time shift to center exposure times, in second.
+        Default is 15 seconds which is half of the exposure time for ZTF.
+    parameters: dict
+        runner_path, userconf, iofile, outdir
+
+    Returns
+    ----------
+    pd.DataFrame
+        Input dataframe with ephemerides columns
+        appended False if query failed somehow
+
+    """
+    # write tmp files on disk
+    date_path = '{}/dates_{}.txt'.format(parameters['outdir'], ident)
+    ephem_path = '{}/ephem_{}.json'.format(parameters['outdir'], ident)
+
+    pdf = pd.DataFrame(jd)
+
+    shift_hour = shift / 24.0 / 3600.0
+    pdf\
+        .apply(lambda epoch: Time(epoch + shift_hour, format='jd').iso)\
+        .to_csv(date_path, index=False, header=False)
+
+    # launch the processing
+    cmd = [
+        parameters['runner_path'],
+        str(ident),
+        str(rplane),
+        str(tcoor),
+        observer,
+        "UTC",
+        parameters['userconf'],
+        parameters['iofile'],
+        parameters['outdir']
+    ]
+
+    # subprocess.run(cmd, capture_output=True)
+    out = subprocess.run(cmd)
+
+    if out.returncode != 0:
+        print("Error code {}".format(out.returncode))
+
+        # clean date file
+        os.remove(date_path)
+
+        return pd.DataFrame()
+
+    # read the data from disk and return
+    with open(ephem_path, 'r') as f:
+        data = json.load(f)
+    ephem = pd.DataFrame(data['data'], columns=data['datacol'].keys())
+
+    # clean tmp files
+    os.remove(ephem_path)
+    os.remove(date_path)
+
+    return ephem
+
+def get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=True, method='rest', parameters={}):
     """ Add ephemerides information from Miriade to a Pandas DataFrame with SSO lightcurve
 
     Parameters
@@ -115,6 +198,10 @@ def get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=True):
     withecl: bool
         If True, query for also for ecliptic Longitude & Latitude (extra call to miriade).
         Default is True.
+    method: str
+        Use the REST API (`rest`), or a local installation of miriade (`ephemcc`)
+    parameters: dict
+        If method == `ephemcc`, specify the mapping of extra parameters here.
 
     Returns
     ----------
@@ -128,13 +215,25 @@ def get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=True):
         mask = pdf['i:ssnamenr'] == ssnamenr
         pdf_sub = pdf[mask]
 
-        eph = query_miriade(
-            str(ssnamenr),
-            pdf_sub['i:jd'],
-            observer=observer,
-            rplane=rplane,
-            tcoor=tcoor
-        )
+        if method == 'rest':
+            eph = query_miriade(
+                str(ssnamenr),
+                pdf_sub['i:jd'],
+                observer=observer,
+                rplane=rplane,
+                tcoor=tcoor
+            )
+        elif method == 'ephemcc':
+            eph = query_miriade_epehemcc(
+                str(ssnamenr),
+                pdf_sub['i:jd'],
+                observer=observer,
+                rplane=rplane,
+                tcoor=tcoor,
+                parameters=parameters
+            )
+        else:
+            raise AssertionError('Method must be `rest` or `ephemcc`. {} not supported'.format(method))
 
         if not eph.empty:
             sc = SkyCoord(eph['RA'], eph['DEC'], unit=(u.deg, u.deg))
@@ -145,12 +244,23 @@ def get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=True):
 
             if withecl:
                 # Add Ecliptic coordinates
-                eph_ec = query_miriade(
-                    str(ssnamenr),
-                    pdf_sub['i:jd'],
-                    observer=observer,
-                    rplane='2'
-                )
+                if method == 'rest':
+                    eph_ec = query_miriade(
+                        str(ssnamenr),
+                        pdf_sub['i:jd'],
+                        observer=observer,
+                        rplane='2'
+                    )
+                elif method == 'ephemcc':
+                    eph_ec = query_miriade_epehemcc(
+                        str(ssnamenr),
+                        pdf_sub['i:jd'],
+                        observer=observer,
+                        rplane='2',
+                        parameters=parameters
+                    )
+                else:
+                    raise AssertionError('Method must be `rest` or `ephemcc`. {} not supported'.format(method))
 
                 sc = SkyCoord(eph_ec['Longitude'], eph_ec['Latitude'], unit=(u.deg, u.deg))
                 eph['Longitude'] = sc.ra.value

--- a/fink_utils/sso/utils.py
+++ b/fink_utils/sso/utils.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import requests
+import subprocess
+import json
 import os
 
 import pandas as pd
 import numpy as np
 
 from astropy.coordinates import SkyCoord
+from astropy.time import Time
 import astropy.units as u
 
 def query_miriade(ident, jd, observer='I41', rplane='1', tcoor=5, shift=15.):


### PR DESCRIPTION
Closes #33 

Now one can use local installation of ephemcc to compute ephemerides. Perfs are somehow slower than the REST API (?):

```python
# take a sso
import requests
import pandas as pd
import numpy as np
import io

# get data for 1465
r = requests.post(
    'https://fink-portal.org/api/v1/sso',
    json={
        'n_or_d': '1465',
        'withEphem': True,
        'output-format': 'json'
    }
)

# Format output in a DataFrame
pdf = pd.read_json(io.BytesIO(r.content))

parameters = {
    'outdir': '/tmp/ramdisk',
    'runner_path': '/home/julien.peloton/miriade/fink_run_ephemcc4.sh',
    'userconf': '/home/julien.peloton/miriade/.eproc-4.3',
    'iofile': '/home/julien.peloton/miriade/default-ephemcc-observation.xml'
}
%timeit get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=False, method='ephemcc', parameters=parameters)
5.5 s ± 141 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit get_miriade_data(pdf, observer='I41', rplane='1', tcoor=5, withecl=False)
4.07 s ± 53.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Note also the case `withecl=True` is not supported unless you specify columns in the `iofile`.