### PR TITLE
Generalised hybrid fit for SSO spins

### DIFF
--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -226,7 +226,7 @@ def estimate_sso_params(
 
         r = ydata.values - func(x, *popt)
         chisq = np.sum((r / pdf['i:sigmapsf'])**2)
-        chisq_red = 1. / len(ydata.values - 1 - nparams) * chisq
+        chisq_red = 1. / (len(ydata.values) - 1 - nparams) * chisq
 
     except RuntimeError as e:
         print(e)

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -328,7 +328,6 @@ def estimate_combined_sso_params(
     dec = np.deg2rad(pdf['i:dec'].values)
 
     filters = np.unique(pdf['i:fid'])
-    nbands = len(filters)
 
     params = ['R', 'alpha', 'beta']
     spin_params = ['H', 'G1', 'G2']
@@ -366,7 +365,7 @@ def estimate_combined_sso_params(
 
         # estimate covariance matrix using the jacobian
         cov = linalg.inv(res_lsq.jac.T @ res_lsq.jac)
-        chi2dof = np.sum(res_lsq.fun**2)/(res_lsq.fun.size - res_lsq.x.size)
+        chi2dof = np.sum(res_lsq.fun**2) / (res_lsq.fun.size - res_lsq.x.size)
         cov *= chi2dof
 
         # 1sigma uncertainty on fitted parameters


### PR DESCRIPTION
Closes #35 

Now we directly estimate:

$$
\begin{equation}
( H^b, G_1^b, G_2^b, R, \alpha_0, \delta_0)_{\forall b}
\end{equation}
$$

from the data. The routine directly reads the number of filters to use from the input dataframe:

```python
import io
import requests
import pandas as pd
from fink_utils.sso.spins import estimate_combined_sso_params

r = requests.post(
  'https://fink-portal.org/api/v1/sso',
  json={
    'n_or_d': '1465',
    'withEphem': True,
    'output-format': 'json'
  }
)

# Format output in a DataFrame
pdf = pd.read_json(io.BytesIO(r.content))
pdf = pdf.sort_values('Phase')

# estimate
outdic = estimate_combined_sso_params(pdf)
```

and output estimates in the form:

```python
# for SSO 1465
{
 'chi2red': 3.175295667832365,
 'R': {'value': 0.46990856103357, 'err': 0.05064079608088972},
 'alpha': {'value': 2.2217183905016267, 'err': 0.02896639589027459},
 'beta': {'value': 0.680062906503769, 'err': 0.181086468343538},
 'H_1': {'value': 11.692574392763927, 'err': 0.3182355287793941},
 'G1_1': {'value': 0.7030921855842638, 'err': 0.43950649791893676},
 'G2_1': {'value': 0.10250454299221043, 'err': 0.11193079582546697},
 'H_2': {'value': 11.27308588057283, 'err': 0.514886011817197},
 'G1_2': {'value': 0.9999999999999999, 'err': 0.796174132121748},
 'G2_2': {'value': 0.024108439425347825, 'err': 0.17679411436621467}
}
```

Reduced chi2 seems better with this technique. Here is an example:

|Method | parameters | $\chi^2_{red}$|
|----|--------|-------------|
| Combined data | ($H$, $G_1$, $G_2$, $R$, $\alpha$, $\beta$) | 6.24 | 
| Per band | ($H^b$, $G_1^b$, $G_2^b$, $R^b$, $\alpha^b$, $\beta^b$) | g=1.37, r=3.99 | 
| Hybrid fit | ($H^b$, $G_1^b$, $G_2^b$, $R$, $\alpha$, $\beta$) | 3.17 | 