### PR TITLE
Unified interface for sso parameter fitting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ omit=
     $SPARK_HOME/*
     setup.py
     dist/*
+    fink_utils/broker/*

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Collection of useful functionalities used across the Fink ecosystem:
 - [data](fink_utils/data): data manipulation with Python
 - [spark](fink_utils/spark): data manipulation with Spark
 - [xmatch](fink_utils/xmatch): utilities for manipulating external databases and catalogs
+- [sso](fink_utils/sso): utilities for manipulating Solar System objects (HG, HG12, HG1G2, SHG1G2)
+- [HBase](fink_utils/hbase): utilities for manipulating data stored in HBase

--- a/fink_utils/__init__.py
+++ b/fink_utils/__init__.py
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -422,7 +422,7 @@ def estimate_sso_params(
     ...    bounds=([0, 0], [30, 1]),
     ...    model='HG',
     ...    normalise_to_V=False)
-    >>> assert len(hg) == 14
+    >>> assert len(hg) == 14, "Found {} parameters: {}".format(len(hg), hg)
 
     >>> hg12 = estimate_sso_params(
     ...    pdf['i:magpsf_red'].values,
@@ -433,7 +433,7 @@ def estimate_sso_params(
     ...    bounds=([0, 0], [30, 1]),
     ...    model='HG12',
     ...    normalise_to_V=False)
-    >>> assert len(hg12) == 14
+    >>> assert len(hg12) == 14, "Found {} parameters: {}".format(len(hg12), hg12)
 
     >>> hg1g2 = estimate_sso_params(
     ...    pdf['i:magpsf_red'].values,
@@ -444,7 +444,7 @@ def estimate_sso_params(
     ...    bounds=([0, 0, 0], [30, 1, 1]),
     ...    model='HG1G2',
     ...    normalise_to_V=False)
-    >>> assert len(hg1g2) == 18
+    >>> assert len(hg1g2) == 18, "Found {} parameters: {}".format(len(hg1g2), hg1g2)
 
     >>> shg1g2 = estimate_sso_params(
     ...    pdf['i:magpsf_red'].values,
@@ -455,7 +455,7 @@ def estimate_sso_params(
     ...    np.deg2rad(pdf['i:dec'].values),
     ...    model='SHG1G2',
     ...    normalise_to_V=False)
-    >>> assert len(shg1g2) == 24
+    >>> assert len(shg1g2) == 27, "Found {} parameters: {}".format(len(shg1g2), shg1g2)
 
     # You can also combine data into single V band
     >>> shg1g2 = estimate_sso_params(
@@ -467,7 +467,7 @@ def estimate_sso_params(
     ...    np.deg2rad(pdf['i:dec'].values),
     ...    model='SHG1G2',
     ...    normalise_to_V=True)
-    >>> assert len(shg1g2) == 18
+    >>> assert len(shg1g2) == 21, "Found {} parameters: {}".format(len(shg1g2), shg1g2)
 
     # If you enter a wrong model name, raise an error
     >>> wrong = estimate_sso_params(
@@ -747,11 +747,15 @@ def fit_spin(
     chisq = np.sum((res_lsq.fun / sigmapsf)**2)
     chisq_red = chisq / (res_lsq.fun.size - res_lsq.x.size - 1)
 
+    geo = spin_angle(ra, dec, popt[params.tolist().index('alpha0')], popt[params.tolist().index('delta0')])
     outdic = {
         'chi2red': chisq_red,
         'rms': rms,
         'minphase': np.min(phase),
         'maxphase': np.max(phase),
+        'minCosLambda': np.min(np.abs(geo)),
+        'meanCosLambda': np.mean(np.abs(geo)),
+        'maxCosLambda': np.max(np.abs(geo)),
         'status': res_lsq.status,
         'fit': 0
     }

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-from scipy.optimize import curve_fit
 from scipy.optimize import least_squares
 from scipy import linalg
 

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -135,61 +135,20 @@ def color_correction_to_V():
 
     return dic
 
-def add_color_correction(pdf):
-    """ Add a new column with color correction `V - band`.
+def compute_color_correction(filters: np.array) -> np.array:
+    """ Return the color correction `V - band` for each measurement.
 
     band --> band + (V - band)
 
     Parameters
     ----------
-    pdf: pd.DataFrame
-        Pandas DataFrame with Fink ZTF data
+    filters: np.array
+        Array with the filter code for each measurement
 
     Returns
     ----------
     out: pd.DataFrame
-        Input Pandas DataFrame with a new column `color_corr`
-    """
-    filts = np.unique(pdf['i:fid'].values)
-    color_sso = np.ones_like(pdf['i:magpsf'])
-    conversion = color_correction_to_V()
-    for i, filt in enumerate(filts):
-        cond = pdf['i:fid'] == filt
-        color_sso[cond] = conversion[filt]
-
-    pdf['color_corr'] = color_sso
-
-    return pdf
-
-def estimate_sso_params(
-        pdf,
-        func,
-        normalise_to_V=False,
-        bounds=([0, 0, 0, 1e-6, 0, -np.pi / 2], [30, 1, 1, 1, 2 * np.pi, np.pi / 2])):
-    """ Fit for phase curve parameters
-
-    Parameters
-    ----------
-    pdf: pd.DataFrame
-        Contain Fink data + ephemerides
-    func: function
-        Parametric function. Currently supported:
-            - func_hg1g2_with_spin
-            - func_hg1g2
-            - func_hg12
-            - func_hg
-    bounds: tuple of lists
-        Parameters boundaries for `func` ([all_mins], [all_maxs]).
-        Defaults are given for `func_hg1g2_with_spin`: (H, G1, G2, R, lambda0, beta0).
-
-    Returns
-    ----------
-    popt: list
-        Estimated parameters for `func`
-    perr: list
-        Error estimates on popt elements
-    chi2_red: float
-        Reduced chi2
+        Array containing the color correction for each measurement
 
     Example
     ---------
@@ -201,7 +160,6 @@ def estimate_sso_params(
     ...     'https://fink-portal.org/api/v1/sso',
     ...     json={
     ...         'n_or_d': '1465',
-    ...         'withEphem': True,
     ...         'output-format': 'json'
     ...     }
     ... )
@@ -209,84 +167,75 @@ def estimate_sso_params(
     # Extract relevant information
     >>> pdf = pd.read_json(io.BytesIO(r.content))
 
-    # Add color correction in the DataFrame
-    >>> pdf = add_color_correction(pdf)
+    # Compute color correction
+    >>> color_to_V = compute_color_correction(pdf['i:fid'].values)
+    >>> assert len(np.unique(color_to_V)) == len(np.unique(pdf['i:fid'].values)), "Filters and colors have different shape!"
+    True
 
-    >>> bounds = ([0, 0, 0, 1e-1, 0, -np.pi/2], [30, 1, 1, 1, 2*np.pi, np.pi/2])
-    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg1g2_with_spin, bounds=bounds)
-    >>> assert popt is not None, "Fit failed!"
-
-    >>> bounds = ([0, 0, 0], [30, 1, 1])
-    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg1g2, bounds=bounds)
-    >>> assert popt is not None, "Fit failed!"
-
-    >>> bounds = ([0, 0], [30, 1])
-    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg12, bounds=bounds)
-    >>> assert popt is not None, "Fit failed!"
-
-    >>> bounds = ([0, 0], [30, 1])
-    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg, bounds=bounds)
-    >>> assert popt is not None, "Fit failed!"
+    >>> assert 0.0 not in color_to_V, "Some filters have no color correction!"
     """
-    if normalise_to_V:
-        ydata = pdf['i:magpsf_red'] + pdf['color_corr']
-        pdf['i:fid'] = 'V'
-    else:
-        ydata = pdf['i:magpsf_red']
+    filts = np.unique(filters)
+    color_sso = np.zeros_like(filters, dtype=float)
+    conversion = color_correction_to_V()
+    for i, filt in enumerate(filts):
+        cond = filters == filt
+        color_sso[cond] = conversion[filt]
 
-    # Fink returns degrees -- convert in radians
-    alpha = np.deg2rad(pdf['Phase'].values)
-    ra = np.deg2rad(pdf['i:ra'].values)
-    dec = np.deg2rad(pdf['i:dec'].values)
-    pha = np.transpose([[i, j, k] for i, j, k in zip(alpha, ra, dec)])
+    return color_sso
 
-    if func.__name__ == 'func_hg1g2_with_spin':
-        nparams = 6
-        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G1, G2, R, alpha, beta) parameters"
-        x = pha
-    elif func.__name__ == 'func_hg1g2':
-        nparams = 3
-        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G1, G2) parameters"
-        x = alpha
-    elif func.__name__ == 'func_hg12':
-        nparams = 2
-        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G12) parameters"
-        x = alpha
-    elif func.__name__ == 'func_hg':
-        nparams = 2
-        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G) parameters"
-        x = alpha
+def build_eqs(x, filters=[], ph=[], rhs=[], func=None):
+    """ Build the system of equations to solve using the HG, HG12, or HG1G2 model
 
-    if not np.alltrue([i == i for i in ydata.values]):
-        popt = [None] * nparams
-        perr = [None] * nparams
-        chisq_red = None
-        return popt, perr, chisq_red
+    Parameters
+    ----------
+    x: list
+        List of parameters to fit for
+    filters: np.array
+        Array of size N containing the filtername for each measurement
+    ph: np.array
+        Array of size N containing phase angles (rad)
+    rhs: np.array
+        Array of size N containing the actual measurements (magnitude)
+    func: callable
+        Model function to use (e.g. `func_hg1g2`)
 
-    try:
-        # TODO: incorporate jacobian and error estimates
-        popt, pcov = curve_fit(
-            func,
-            x,
-            ydata.values,
-            # sigma=pdf['i:sigmapsf'],
-            bounds=bounds,
-            # jac=Dfunc_hg1g2_with_spin
-        )
+    Returns
+    ----------
+    out: np.array
+        Array of size N containing (model - y)
 
-        perr = np.sqrt(np.diag(pcov))
+    Notes
+    ----------
+    the input `x` contains filter dependent variables,
+    that is (Hs and Gs). For example with two bands g & r with the HG1G2 model:
 
-        r = ydata.values - func(x, *popt)
-        chisq = np.sum((r / pdf['i:sigmapsf'])**2)
-        chisq_red = 1. / (len(ydata.values) - 1 - nparams) * chisq
+    ```
+    x = [
+        h_g, g_1_g, g_2_g,
+        h_r, g_1_r, g_2_r
+    ]
+    ```
 
-    except RuntimeError as e:
-        print(e)
-        popt = [None] * nparams
-        perr = [None] * nparams
-        chisq_red = None
+    """
+    filternames = np.unique(filters)
 
-    return popt, perr, chisq_red
+    params = x
+    nparams = len(params) / len(filternames)
+    assert int(nparams) == nparams, "You need to input all parameters for all bands"
+
+    params_per_band = np.reshape(params, (len(filternames), int(nparams)))
+    eqs = []
+    for index, filtername in enumerate(filternames):
+        mask = filters == filtername
+
+        myfunc = func(
+            ph[mask],
+            *params_per_band[index],
+        ) - rhs[mask]
+
+        eqs = np.concatenate((eqs, myfunc))
+
+    return np.ravel(eqs)
 
 def build_eqs_for_spins(x, filters=[], ph=[], ra=[], dec=[], rhs=[]):
     """ Build the system of equations to solve using the HG1G2 + spin model
@@ -348,7 +297,271 @@ def build_eqs_for_spins(x, filters=[], ph=[], ra=[], dec=[], rhs=[]):
 
     return np.ravel(eqs)
 
-def estimate_hybrid_sso_params(
+def estimate_sso_params(
+        magpsf_red, sigmapsf, phase, filters, ra=None, dec=None,
+        model='SHG1G2',
+        normalise_to_V=False,
+        p0=[15.0, 0.15, 0.15, 0.8, np.pi, 0.0],
+        bounds=([0, 0, 0, 1e-1, 0, -np.pi / 2], [30, 1, 1, 1, 2 * np.pi, np.pi / 2])):
+    """ Fit for phase curve parameters
+
+    Under the hood, it uses a `least_square`. Along with the fitted parameters,
+    we also provide flag to assess the quality of the fit:
+
+    Code for quality `fit`:
+    0: success
+    1: bad_vals
+    2: MiriadeFail
+    3: RunTimError
+    4: LinalgError
+
+    Code for quality `status` (least square convergence):
+    -2: failure
+    -1 : improper input parameters status returned from MINPACK.
+    0 : the maximum number of function evaluations is exceeded.
+    1 : gtol termination condition is satisfied.
+    2 : ftol termination condition is satisfied.
+    3 : xtol termination condition is satisfied.
+    4 : Both ftol and xtol termination conditions are satisfied.
+
+    Typically, one would only trust status = 2 and 4.
+
+
+    Parameters
+    ----------
+    magpsf_red: array
+        Reduced magnitude, that is m_obs - 5 * np.log10('Dobs' * 'Dhelio')
+    sigmapsf: array
+        Error estimates on magpsf_red
+    phase: array
+        Phase angle [rad]
+    filters: array
+        Filter name for each measurement.
+    ra: optional, array
+        Right ascension [rad]. Required for SHG1G2 model.
+    dec: optional, array
+        Declination [rad]. Required for SHG1G2 model.
+    model: str
+        Parametric function. Currently supported:
+            - SHG1G2 (default)
+            - HG1G2
+            - HG12
+            - HG
+    normalise_to_V: optional, bool
+        If True, bring all bands to V. Default is False.
+    p0: list
+        Initial guess for input parameters. If there are several bands,
+        we replicate the bounds for all. Note that in the case of SHG1G2,
+        the spin parameters are fitted globally (and not per band).
+    bounds: tuple of lists
+        Parameters boundaries ([all_mins], [all_maxs]).
+        Lists should be ordered as:
+            - SHG1G2: (H, G1, G2, R, alpha, beta)
+            - HG1G2: (H, G1, G2)
+            - HG12: (H, G12)
+            - HG: (H, G)
+        Note that even if there is several bands `b`, we take the same
+        bounds for all H's and G's.
+
+    Returns
+    ----------
+    outdic: dict
+        Dictionary containing reduced chi2, and estimated parameters and
+        error on each parameters.
+    """
+    if normalise_to_V:
+        color = compute_color_correction(filters)
+        ydata = magpsf_red + color
+        filters = np.array(['V'] * len(filters))
+    else:
+        ydata = magpsf_red
+
+    if model == 'SHG1G2':
+        outdic = fit_spin(
+            ydata,
+            sigmapsf,
+            phase,
+            ra,
+            dec,
+            filters,
+            p0=p0,
+            bounds=bounds
+        )
+    elif model in ['HG', 'HG12', 'HG1G2']:
+        outdic = fit_legacy_models(
+            ydata,
+            sigmapsf,
+            phase,
+            filters,
+            model,
+            p0=p0,
+            bounds=bounds
+        )
+    else:
+        raise AssertionError('model {} is not understood. Please choose among: SHG1G2, HG1G2, HG12, HG'.format(model))
+
+    return outdic
+
+
+def fit_legacy_models(
+        magpsf_red, sigmapsf, phase, filters,
+        model,
+        p0=[15, 0.15, 0.15],
+        bounds=([0, 0, 0], [30, 1, 1])):
+    """ Fit for phase curve parameters
+
+    Parameters
+    ----------
+    magpsf_red: array
+        Reduced magnitude, that is m_obs - 5 * np.log10('Dobs' * 'Dhelio')
+    sigmapsf: array
+        Error estimates on magpsf_red
+    phase: array
+        Phase angle [rad]
+    filters: array
+        Filter name for each measurement
+    model: function
+        Parametric function. Currently supported:
+            - func_hg1g2
+            - func_hg12
+            - func_hg
+    bounds: tuple of lists
+        Parameters boundaries for `func` ([all_mins], [all_maxs]).
+        Defaults are given for `func_hg1g2_with_spin`: (H, G1, G2, R, lambda0, beta0).
+
+    Returns
+    ----------
+    popt: list
+        Estimated parameters for `func`
+    perr: list
+        Error estimates on popt elements
+    chi2_red: float
+        Reduced chi2
+
+    Example
+    ---------
+    >>> import io
+    >>> import requests
+    >>> import pandas as pd
+
+    >>> r = requests.post(
+    ...     'https://fink-portal.org/api/v1/sso',
+    ...     json={
+    ...         'n_or_d': '1465',
+    ...         'withEphem': True,
+    ...         'output-format': 'json'
+    ...     }
+    ... )
+
+    # Extract relevant information
+    >>> pdf = pd.read_json(io.BytesIO(r.content))
+
+    # Add color correction in the DataFrame
+    >>> pdf = add_color_correction(pdf)
+
+    >>> bounds = ([0, 0, 0, 1e-1, 0, -np.pi/2], [30, 1, 1, 1, 2*np.pi, np.pi/2])
+    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg1g2_with_spin, bounds=bounds)
+    >>> assert popt is not None, "Fit failed!"
+
+    >>> bounds = ([0, 0, 0], [30, 1, 1])
+    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg1g2, bounds=bounds)
+    >>> assert popt is not None, "Fit failed!"
+
+    >>> bounds = ([0, 0], [30, 1])
+    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg12, bounds=bounds)
+    >>> assert popt is not None, "Fit failed!"
+
+    >>> bounds = ([0, 0], [30, 1])
+    >>> popt, perr, chisq_red = estimate_sso_params(pdf, func=func_hg, bounds=bounds)
+    >>> assert popt is not None, "Fit failed!"
+    """
+    if model == 'HG1G2':
+        func = func_hg1g2
+        nparams = 3
+        params_ = ['H', 'G1', 'G2']
+        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G1, G2) parameters"
+    elif model == 'HG12':
+        func = func_hg12
+        nparams = 2
+        params_ = ['H', 'G12']
+        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G12) parameters"
+    elif model == 'HG':
+        func = func_hg
+        nparams = 2
+        params_ = ['H', 'G']
+        assert len(bounds[0]) == nparams, "You need to specify bounds on all (H, G) parameters"
+
+    ufilters = np.unique(filters)
+
+    params = []
+    for filt in ufilters:
+        tmp = [i + '_{}'.format(str(filt)) for i in params_]
+        params = np.concatenate((params, tmp))
+
+    initial_guess = []
+    for filt in ufilters:
+        initial_guess = np.concatenate((initial_guess, p0))
+
+    lower_bounds = []
+    upper_bounds = []
+    for filt in ufilters:
+        lower_bounds = np.concatenate((lower_bounds, bounds[0]))
+        upper_bounds = np.concatenate((upper_bounds, bounds[1]))
+
+    if not np.alltrue([i == i for i in magpsf_red]):
+        outdic = {'fit': 1, 'status': -2}
+        return outdic
+
+    try:
+        res_lsq = least_squares(
+            build_eqs,
+            x0=initial_guess,
+            bounds=(lower_bounds, upper_bounds),
+            jac='2-point',
+            loss='linear',
+            args=(filters, phase, magpsf_red, func)
+        )
+
+    except RuntimeError:
+        outdic = {'fit': 3, 'status': -2}
+        return outdic
+
+    popt = res_lsq.x
+
+    # estimate covariance matrix using the jacobian
+    try:
+        cov = linalg.inv(res_lsq.jac.T @ res_lsq.jac)
+        chi2dof = np.sum(res_lsq.fun**2) / (res_lsq.fun.size - res_lsq.x.size)
+        cov *= chi2dof
+
+        # 1sigma uncertainty on fitted parameters
+        perr = np.sqrt(np.diag(cov))
+    except np.linalg.LinAlgError:
+        # raised if jacobian is degenerated
+        outdic = {'fit': 4, 'status': res_lsq.status}
+        return outdic
+
+    rms = np.sqrt(np.mean(res_lsq.fun**2))
+
+    # For the chi2, we use the error estimate from the data directly
+    chisq = np.sum((res_lsq.fun / sigmapsf)**2)
+    chisq_red = chisq / (res_lsq.fun.size - res_lsq.x.size - 1)
+
+    outdic = {
+        'chi2red': chisq_red,
+        'rms': rms,
+        'minphase': np.min(phase),
+        'maxphase': np.max(phase),
+        'status': res_lsq.status,
+        'fit': 0
+    }
+    for i in range(len(params)):
+        outdic[params[i]] = popt[i]
+        outdic['err' + params[i]] = perr[i]
+
+    return outdic
+
+def fit_spin(
         magpsf_red, sigmapsf, phase, ra, dec, filters,
         p0=[15.0, 0.15, 0.15, 0.8, np.pi, 0.0],
         bounds=([0, 0, 0, 1e-1, 0, -np.pi / 2], [30, 1, 1, 1, 2 * np.pi, np.pi / 2])):

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -289,19 +289,19 @@ def build_eqs_for_spins(x, filters=[], ph=[], ra=[], dec=[], rhs=[]):
     Notes
     ----------
     the input `x` should start with filter independent variables,
-    that is (R, alpha, beta), followed by filter dependent variables,
+    that is (R, alpha, delta), followed by filter dependent variables,
     that is (H, G1, G2). For example with two bands g & r:
 
     ```
     x = [
-        R, alpha, beta,
+        R, alpha, delta,
         h_g, g_1_g, g_2_g,
         h_r, g_1_r, g_2_r
     ]
     ```
 
     """
-    R, alpha, beta = x[0:3]
+    R, alpha, delta = x[0:3]
     filternames = np.unique(filters)
 
     params = x[3:]
@@ -316,7 +316,7 @@ def build_eqs_for_spins(x, filters=[], ph=[], ra=[], dec=[], rhs=[]):
         myfunc = func_hg1g2_with_spin(
             np.vstack([ph[mask].tolist(), ra[mask].tolist(), dec[mask].tolist()]),
             params_per_band[index][0], params_per_band[index][1], params_per_band[index][2],
-            R, alpha, beta
+            R, alpha, delta
         ) - rhs[mask]
 
         eqs = np.concatenate((eqs, myfunc))
@@ -382,7 +382,7 @@ def estimate_sso_params(
     bounds: tuple of lists
         Parameters boundaries ([all_mins], [all_maxs]).
         Lists should be ordered as:
-            - SHG1G2: (H, G1, G2, R, alpha, beta)
+            - SHG1G2: (H, G1, G2, R, alpha, delta)
             - HG1G2: (H, G1, G2)
             - HG12: (H, G12)
             - HG: (H, G)
@@ -677,11 +677,11 @@ def fit_spin(
     filters: array
         Filter name for each measurement
     p0: list
-        Initial guess for [H, G1, G2, R, alpha, beta]. Note that even if
+        Initial guess for [H, G1, G2, R, alpha, delta]. Note that even if
         there is several bands `b`, we take the same initial guess for all (H^b, G1^b, G2^b).
     bounds: tuple of lists
         Parameters boundaries for `func_hg1g2_with_spin` ([all_mins], [all_maxs]).
-        Lists should be ordered as: (H, G1, G2, R, alpha, beta). Note that even if
+        Lists should be ordered as: (H, G1, G2, R, alpha, delta). Note that even if
         there is several bands `b`, we take the same bounds for all (H^b, G1^b, G2^b).
 
     Returns

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -97,8 +97,11 @@ def func_hg1g2(ph, h, g1, g2):
 
     return h + func1
 
-def func_hg1g2_with_spin(pha, h, g1, g2, R, lambda0, beta0):
-    """ Return f(H, G1, G2, R, lambda0, beta0) part of the lightcurve in mag space
+def spin_angle(ra, dec, alpha0, delta0):
+    return np.sin(dec) * np.sin(delta0) + np.cos(dec) * np.cos(delta0) * np.cos(ra - alpha0)
+
+def func_hg1g2_with_spin(pha, h, g1, g2, R, alpha0, delta0):
+    """ Return f(H, G1, G2, R, alpha0, delta0) part of the lightcurve in mag space
 
     Parameters
     ----------
@@ -112,9 +115,9 @@ def func_hg1g2_with_spin(pha, h, g1, g2, R, lambda0, beta0):
         G2 parameter (no unit)
     R: float
         Oblateness (no units)
-    lambda0: float
+    alpha0: float
         RA of the spin (radian)
-    beta0: float
+    delta0: float
         Dec of the spin (radian)
 
     Returns
@@ -130,7 +133,7 @@ def func_hg1g2_with_spin(pha, h, g1, g2, R, lambda0, beta0):
     func1 = func_hg1g2(ph, h, g1, g2)
 
     # Spin part
-    geo = np.sin(dec) * np.sin(beta0) + np.cos(dec) * np.cos(beta0) * np.cos(ra - lambda0)
+    geo = spin_angle(ra, dec, alpha0, delta0)
     func2 = 1 - (1 - R) * np.abs(geo)
     func2 = -2.5 * np.log10(func2)
 
@@ -537,7 +540,7 @@ def fit_legacy_models(
             - func_hg
     bounds: tuple of lists
         Parameters boundaries for `func` ([all_mins], [all_maxs]).
-        Defaults are given for `func_hg1g2_with_spin`: (H, G1, G2, R, lambda0, beta0).
+        Defaults are given for `func_hg1g2_with_spin`: (H, G1, G2, R, alpha0, delta0).
 
     Returns
     ----------

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Le Montagner Roman
+# Copyright 2022 Astrolab Software
 # Author: Le Montagner Roman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,30 +17,12 @@
 
 set -e
 
-python -m pip install .
-
 export ROOTPATH=`pwd`
-# source ${FINK_BROKER}/conf/fink.conf.prod
 
-# export FINK_PACKAGES=$FINK_PACKAGES
-# export FINK_JARS=$FINK_JARS
-# export KAFKA_IPPORT_SIM=$KAFKA_IPPORT_SIM
-# export KAFKA_TOPIC="ztf-stream-sim"
-
-# Add coverage_daemon to the pythonpath. See python/fink_broker/tester.py
 export PYTHONPATH="${SPARK_HOME}/python/test_coverage:$PYTHONPATH"
 export COVERAGE_PROCESS_START=".coveragerc"
 
-# echo "pytest -q fink_utils/photometry/test.py"
-# pytest -q fink_utils/photometry/test.py
-
-# echo "fink_utils/xmatch/simbad.py"
-# coverage run \
-#     --source=${ROOTPATH} \
-#     --rcfile .coveragerc \
-#     fink_utils/xmatch/simbad.py
-
-for filename in fink_utils/broker/*.py
+for filename in fink_utils/test/*.py
 do
     echo $filename
     coverage run \
@@ -49,7 +31,7 @@ do
     $filename
 done
 
-for filename in fink_utils/test/*.py
+for filename in fink_utils/sso/*.py
 do
     echo $filename
     coverage run \


### PR DESCRIPTION
This PR unifies the way SSO lightcurves are fitted:
- Now there is only one function to estimate parameters `estimate_sso_params`. 
- This function uses `least_square` under the hood.
- This function takes the model name as an input, and the rest is passed accordingly (bounds, `p0`, etc.). 
- The output is a dictionary containing fitted parameters. 
- If several bands are detected in input, then it fits parameters for each band. 
- User can also specify to combine all measurements into a common `V` band.  

Example:

```python
# HG model -- multiband
hg = estimate_sso_params(
    pdf['i:magpsf_red'].values,
    pdf['i:sigmapsf'].values,
    np.deg2rad(pdf['Phase'].values),
    pdf['i:fid'].values,
    p0=[15.0, 0.15],
    bounds=([0, 0], [30, 1]),
    model='HG',
    normalise_to_V=False
)

# HG12 model -- multiband
hg12 = estimate_sso_params(
    pdf['i:magpsf_red'].values,
    pdf['i:sigmapsf'].values,
    np.deg2rad(pdf['Phase'].values),
    pdf['i:fid'].values,
    p0=[15.0, 0.15],
    bounds=([0, 0], [30, 1]),
    model='HG12',
    normalise_to_V=False
)

# HG1G2 model -- multiband
hg1g2 = estimate_sso_params(
    pdf['i:magpsf_red'].values,
    pdf['i:sigmapsf'].values,
    np.deg2rad(pdf['Phase'].values),
    pdf['i:fid'].values,
    p0=[15.0, 0.15, 0.15],
    bounds=([0, 0, 0], [30, 1, 1]),
    model='HG1G2',
    normalise_to_V=False
)

# S1G2 model -- multiband
shg1g2 = estimate_sso_params(
    pdf['i:magpsf_red'].values,
    pdf['i:sigmapsf'].values,
    np.deg2rad(pdf['Phase'].values),
    pdf['i:fid'].values,
    np.deg2rad(pdf['i:ra'].values),
    np.deg2rad(pdf['i:dec'].values),
    model='SHG1G2',
    normalise_to_V=False
)
```

For example the output of the last call is of the form (two bands 1 & 2):

```python
{'chi2red': 7.035912678679952,
 'rms': 0.07300671397482283,
 'minphase': 0.020122891160539075,
 'maxphase': 0.37293579280688793,
 'status': 2,
 'fit': 0,
 'R': 0.10000000001120372,
 'errR': 0.5023658866615439,
 'alpha0': 4.909136515956984,
 'erralpha0': 0.032407101850345066,
 'delta0': 0.49198474992143326,
 'errdelta0': 0.44641542389175387,
 'H_1': 9.72588082625722,
 'errH_1': 0.09996823734840038,
 'G1_1': 0.49937609492977186,
 'errG1_1': 0.14786403605552573,
 'G2_1': 0.25618407257665343,
 'errG2_1': 0.0539270047008662,
 'H_2': 9.175893990963957,
 'errH_2': 0.11560654457786192,
 'G1_2': 0.34784478933318136,
 'errG1_2': 0.15724005955555895,
 'G2_2': 0.3278772529456445,
 'errG2_2': 0.05583200684137898}
```