### PR TITLE
Add utils to push to Telegram channels

### DIFF
--- a/fink_utils/__init__.py
+++ b/fink_utils/__init__.py
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/fink_utils/tg_bot/utils.py
+++ b/fink_utils/tg_bot/utils.py
@@ -1,0 +1,350 @@
+# Copyright 2023-2024 AstroLab Software
+# Author: Тимофей Пшеничный, Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Part of these functionalities were taken from the Anomaly detection module """
+import os
+import io
+import time
+import requests
+import pandas as pd
+import numpy as np
+import gzip
+from astropy.io import fits
+
+import matplotlib.pyplot as plt
+
+from PIL import Image
+
+from fink_science.image_classification.utils import img_normalizer
+from fink_utils.data.utils import extract_field
+
+COLORS_ZTF = {1: "#15284F", 2: "#F5622E"}
+
+
+def status_check(res, header, sleep=8, timeout=25):
+    """Checks whether the request was successful.
+    In case of an error, sends information about the error to the @fink_test telegram channel
+
+    Parameters
+    ----------
+    res : Response object
+
+    Returns
+    -------
+        result : bool
+            True : The request was successful
+            False: The request was executed with an error
+    """
+    if res.status_code != 200:
+        msg = """
+        {}
+        Content: {}
+        """.format(
+            header, res.content
+        )
+        url = "https://api.telegram.org/bot"
+        url += os.environ["FINK_TG_TOKEN"]
+        method = url + "/sendMessage"
+        time.sleep(sleep)
+        requests.post(
+            method, data={"chat_id": "@fink_bot_error", "text": msg}, timeout=timeout
+        )
+        return False
+    return True
+
+
+def msg_handler_tg(tg_data, channel_id, init_msg, timeout=25):
+    """
+    Notes
+    ----------
+    The function sends notifications to the "channel_id" channel of Telegram.
+
+    Parameters
+    ----------
+    tg_data: list
+        List of tuples. Each item is a separate notification.
+        Content of the tuple:
+            text_data : str
+                Notification text
+            cutout : BytesIO stream
+                cutout image in png format
+            curve : BytesIO stream
+                light curve picture
+    channel_id: string
+        Channel id in Telegram
+    init_msg: str
+        Initial message
+
+    Returns
+    -------
+        None
+    """
+    url = "https://api.telegram.org/bot"
+    url += os.environ["FINK_TG_TOKEN"]
+    method = url + "/sendMediaGroup"
+
+    if init_msg != "":
+        res = requests.post(
+            url + "/sendMessage",
+            data={"chat_id": channel_id, "text": init_msg, "parse_mode": "markdown"},
+            timeout=timeout,
+        )
+        status_check(res, header=channel_id)
+    for text_data, cutout, curve in tg_data:
+        files = {"first": curve}
+        media = [
+            {
+                "type": "photo",
+                "media": "attach://first",
+                "caption": text_data,
+                "parse_mode": "markdown",
+            }
+        ]
+        if cutout is not None:
+            files.update({"second": cutout})
+            media.append({"type": "photo", "media": "attach://second"})
+        res = requests.post(
+            method,
+            params={"chat_id": channel_id, "media": str(media).replace("'", '"')},
+            files=files,
+            timeout=timeout,
+        )
+        status_check(res, header=channel_id)
+        time.sleep(10)
+
+
+def get_cutout(cutout=None, ztf_id=None, origin="alert"):
+    """Loads cutout image from alert packet or via Fink API
+
+    Parameters
+    ----------
+    cutout: bytes, optional
+        Gzipped FITS file from alert packet. Only
+        used for origin=alert.
+    ztf_id : str, optional
+        unique identifier for this object. Only
+        used for origin=API.
+    origin: str, optional
+        Choose between `alert`[default], or API.
+
+    Returns
+    ----------
+    out : BytesIO stream
+        cutout image in png format
+    """
+    if origin == "API":
+        assert ztf_id is not None
+        r = requests.post(
+            "https://fink-portal.org/api/v1/cutouts",
+            json={
+                "objectId": ztf_id,
+                "kind": "Difference",
+            },
+            timeout=25,
+        )
+        status_check(r)
+        data = io.BytesIO(r.content)
+    elif origin == "alert":
+        assert cutout is not None
+
+        # Unzip
+        with gzip.open(io.BytesIO(cutout), "rb") as fits_file:
+            with fits.open(
+                io.BytesIO(fits_file.read()), ignore_missing_simple=True
+            ) as hdul:
+                img = hdul[0].data[::-1]
+
+        # Set the contrast
+        img = np.nan_to_num(img)
+        img = img_normalizer(img, 0, 255)
+
+        # Make a PNG
+        img = Image.fromarray(img).convert("L")
+        _ = plt.figure(figsize=(15, 6))
+        plt.imshow(img, cmap="gray", vmin=0, vmax=255)
+        data = io.BytesIO()
+        plt.savefig(data, format="png")
+        data.seek(0)
+    else:
+        data = io.BytesIO()
+
+    return data
+
+
+def get_curve(
+    alert=None,
+    jd=None,
+    magpsf=None,
+    sigmapsf=None,
+    diffmaglim=None,
+    fid=None,
+    objectId=None,
+    origin="API",
+):
+    """Generate PNG lightcurve
+
+    Notes
+    ----------
+    Based on `origin`, the other arguments are mandatory:
+    - origin=API: objectId
+    - origin=alert: alert
+    - origin=fields: objectId, jd, magpsf, sigmapsf, diffmaglim, fid
+
+    Parameters
+    ----------
+    alert: dict, optional
+        alert packet containing `objectId`, `candidate`, `prv_candidates`
+    jd: np.array, optional
+        Vector of times.
+    magpsf: np.array, optional
+        Vector of difference magnitudes.
+    sigmapsf: np.array, optional
+        Vector of error on difference magnitudes.
+    diffmaglim: np.array, optional
+        Vector of upper limits on magnitude.
+    fid: np.array, optional
+        Vector of filter ID.
+    objectId : str
+        unique identifier for this object
+    origin: str, optional
+        Choose between `alert`, `API`[default], or `fields`.
+
+    Returns
+    -------
+    out : BytesIO stream
+        light curve picture
+    """
+    filter_dict = {1: "g band", 2: "r band"}
+    if origin == "API":
+        assert objectId is not None
+
+        r = requests.post(
+            "https://fink-portal.org/api/v1/objects",
+            json={
+                "objectId": objectId,
+                "columns": "i:jd,i:fid,i:magpsf,i:sigmapsf,d:tag",
+                "withupperlim": "True",
+            },
+        )
+        if not status_check(r):
+            return None
+
+        # Format output in a DataFrame
+        pdf = pd.read_json(io.BytesIO(r.content))
+
+        plt.figure(figsize=(15, 10))
+
+        for filt in pdf["i:fid"].unique():
+            maskFilt = pdf["i:fid"] == filt
+
+            # The column `d:tag` is used to check data type
+            maskValid = pdf["d:tag"] == "valid"
+            plt.errorbar(
+                pdf[maskValid & maskFilt]["i:jd"].apply(lambda x: x - 2400000.5),
+                pdf[maskValid & maskFilt]["i:magpsf"],
+                pdf[maskValid & maskFilt]["i:sigmapsf"],
+                ls="",
+                marker="o",
+                color=COLORS_ZTF[filt],
+                label=filter_dict[filt],
+            )
+
+            maskUpper = pdf["d:tag"] == "upperlim"
+            plt.plot(
+                pdf[maskUpper & maskFilt]["i:jd"].apply(lambda x: x - 2400000.5),
+                pdf[maskUpper & maskFilt]["i:diffmaglim"],
+                ls="",
+                marker="^",
+                color=COLORS_ZTF[filt],
+                markerfacecolor="none",
+            )
+
+            maskBadquality = pdf["d:tag"] == "badquality"
+            plt.errorbar(
+                pdf[maskBadquality & maskFilt]["i:jd"].apply(lambda x: x - 2400000.5),
+                pdf[maskBadquality & maskFilt]["i:magpsf"],
+                pdf[maskBadquality & maskFilt]["i:sigmapsf"],
+                ls="",
+                marker="v",
+                color=COLORS_ZTF[filt],
+            )
+
+        plt.gca().invert_yaxis()
+        plt.legend()
+        plt.xlabel("Modified Julian Date")
+        plt.ylabel("Difference magnitude")
+
+        buf = io.BytesIO()
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+        plt.close()
+
+    elif origin in ["alert", "fields"]:
+        if origin == "alert":
+            # extract current and historical data as one vector
+            magpsf = extract_field(alert, "magpsf")
+            sigmapsf = extract_field(alert, "sigmapsf")
+            diffmaglim = extract_field(alert, "diffmaglim")
+            fid = extract_field(alert, "fid")
+            jd = extract_field(alert, "jd")
+            objectId = alert["objectId"]
+
+        # Rescale dates to MJD
+        dates = np.array([i - 2400000.5 for i in jd])
+
+        # loop over filters
+        fig = plt.figure(num=1, figsize=(12, 4))
+
+        # Loop over each filter
+        for filt in COLORS_ZTF.keys():
+            mask = np.where(fid == filt)[0]
+
+            # Skip if no data
+            if len(mask) == 0:
+                continue
+
+            # y data
+            maskNotNone = magpsf[mask] != None
+            plt.errorbar(
+                dates[mask][maskNotNone],
+                magpsf[mask][maskNotNone],
+                yerr=sigmapsf[mask][maskNotNone],
+                color=COLORS_ZTF[filt],
+                marker="o",
+                ls="",
+                label=filter_dict[filt],
+                mew=4,
+            )
+            # Upper limits
+            plt.plot(
+                dates[mask][~maskNotNone],
+                diffmaglim[mask][~maskNotNone],
+                color=COLORS_ZTF[filt],
+                marker="v",
+                ls="",
+                mew=4,
+                alpha=0.5,
+            )
+            plt.title(objectId)
+        plt.legend()
+        plt.gca().invert_yaxis()
+        plt.xlabel("Days to candidate")
+        plt.ylabel("Difference magnitude")
+
+        buf = io.BytesIO()
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+        plt.close()
+
+    return buf


### PR DESCRIPTION
Contains:
- generate lightcurve as PNG. Data is taken either from API or the alert packet itself.
- generate cutout as PNG
- send payload (text, lightcurve, cutout) to a channel

Any error is sent to the channel `fink_bot_error`. For the future: build composite lightcurve from API + alert packet.