### PR TITLE
Issue/110/sidereal

### DIFF
--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -280,7 +280,7 @@ def func_sshg1g2(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0):
     sin_aspect_2 = 1 - cos_aspect_2
 
     # Sidereal
-    W = rotation_phase(ep, phi0, 2 * np.pi * period, t0)
+    W = rotation_phase(ep, phi0, 2 * np.pi / period, t0)
     rot_phase = subobserver_longitude(ra, dec, alpha0, delta0, W)
 
     # https://ui.adsabs.harvard.edu/abs/1985A%26A...149..186P/abstract

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -830,23 +830,23 @@ def fit_legacy_models(
         func = func_hg1g2
         nparams = 3
         params_ = ["H", "G1", "G2"]
-        assert (
-            len(bounds[0]) == nparams
-        ), "You need to specify bounds on all (H, G1, G2) parameters"
+        assert len(bounds[0]) == nparams, (
+            "You need to specify bounds on all (H, G1, G2) parameters"
+        )
     elif model == "HG12":
         func = func_hg12
         nparams = 2
         params_ = ["H", "G12"]
-        assert (
-            len(bounds[0]) == nparams
-        ), "You need to specify bounds on all (H, G12) parameters"
+        assert len(bounds[0]) == nparams, (
+            "You need to specify bounds on all (H, G12) parameters"
+        )
     elif model == "HG":
         func = func_hg
         nparams = 2
         params_ = ["H", "G"]
-        assert (
-            len(bounds[0]) == nparams
-        ), "You need to specify bounds on all (H, G) parameters"
+        assert len(bounds[0]) == nparams, (
+            "You need to specify bounds on all (H, G) parameters"
+        )
 
     ufilters = np.unique(filters)
 


### PR DESCRIPTION
Correction of major typo in "func_sshg1g2": the angular velocity W was written as 2pi*period, I corrected it to 2pi/period.
I ran some tests offline on SSO 9979
- RMS sHG1G2 0.063 mag
- RMS ssHG1G2 0.047 mag  <-- the version with a simple rotation phase, used in the first wide computation (24/10)
- RMS ssHG1G2 0.063 mag  <-- current version of sidereal: the fact that RMS does not improve vs sHG1G2 is suspicious
- RMS ssHG1G2 0.047 mag  <-- with the proposed PR