### PR TITLE
correct equation for subobserver, see issue #123

### DIFF
--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -221,7 +221,7 @@ def subobserver_longitude(ra, dec, ra0, dec0, W):
     float: The subobserver longitude in radians.
     """
     x = -np.cos(dec0) * np.sin(dec) + np.sin(dec0) * np.cos(dec) * np.cos(ra - ra0)
-    y = -(np.cos(dec0) * np.sin(ra - ra0))
+    y = -(np.cos(dec) * np.sin(ra - ra0))
     return W - np.arctan2(x, y)
 
 


### PR DESCRIPTION
See info in issue #123 

Now, some tests :-)
1) Hektor, ssHGG with "standard" p0 (the one from sHGG):
       sHG1G2  ssHG1G2
RMS  :  0.208   0.211
chi2 : 66.039  68.515
--> no improvement... :-(

2) Hektor, ssHGG with the **alternative** spin (flipped from sHGG)
      sHG1G2  ssHG1G2
RMS  :  0.208   0.055
chi2 : 66.039   4.018
--> Champagne

In some cases, ssHGG can break the spin degeneracy (I ran tests on a few others, some cases remain ambiguous) 
