### PR TITLE
Updated spins.py to include model fitting with optional terminator-defined ellipse shadowing correction

### DIFF
--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -426,6 +426,7 @@ def func_sshg1g2_terminator(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, ph
     -------
     out: array of floats
         H - 2.5 log(f(G1G2)) - 2.5 log(f(spin, shape))
+        Similar to the ssHG1G2 model, but including the correction for the non-illuminated part of the asteroid
     """
     ph = pha[0]
     ra = pha[1]
@@ -500,7 +501,7 @@ def illum_and_shadowed_areas(coords, alpha0, delta0, period, a_b, a_c, phi0):
 
     Parameters
     ----------
-    coords: array-like [6]
+    coords: array-like [5]
         List containing [SEP_RA  in radians, SEP_Dec in radians, time (jd),
                          SSP_RA sun in radians, SSP_DEC sun in radians
     alpha0: float
@@ -818,6 +819,7 @@ def build_eqs_for_spin_shape(
         Array of size N containing the solar RA (radian), required if terminator=True
     dec_s: optional, np.array
         Array of size N containing the solar DEC (radian), required if terminator=True
+
     Returns
     -------
     out: np.array
@@ -837,7 +839,6 @@ def build_eqs_for_spin_shape(
     ]
     ```
     """
-
     alpha, delta, period, a_b, a_c, phi0 = x[0:6]
     filternames = np.unique(filters)
 

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -392,6 +392,10 @@ def sfhg1g2_error_fun(params, phas, mags):
 def func_sshg1g2_terminator(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0):
     """Extension of the ssHG1G2 model with correction for the non-illuminated part
 
+    Notes
+    -----
+    Absolute magnitude is computed according to Ostro & Connelly (1984)
+
     Parameters
     ----------
     pha: array-like [6, N]

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -390,7 +390,7 @@ def sfhg1g2_error_fun(params, phas, mags):
 
 
 def func_sshg1g2_terminator(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0):
-    """Return f(H, G1, G2, alpha0, delta0, period, a_b, a_c, phi0) part of the lightcurve in mag space
+    """Extension of the ssHG1G2 model with correction for the non-illuminated part
 
     Parameters
     ----------
@@ -854,14 +854,12 @@ def build_eqs_for_spin_shape(
 
             myfunc = (
                 func_sshg1g2(
-                    np.vstack(
-                        [
-                            ph[mask].tolist(),
-                            ra[mask].tolist(),
-                            dec[mask].tolist(),
-                            jd[mask].tolist(),
-                        ]
-                    ),
+                    np.vstack([
+                        ph[mask].tolist(),
+                        ra[mask].tolist(),
+                        dec[mask].tolist(),
+                        jd[mask].tolist(),
+                    ]),
                     params_per_band[index][0],
                     params_per_band[index][1],
                     params_per_band[index][2],
@@ -882,16 +880,14 @@ def build_eqs_for_spin_shape(
 
             myfunc = (
                 func_sshg1g2_terminator(
-                    np.vstack(
-                        [
-                            ph[mask].tolist(),
-                            ra[mask].tolist(),
-                            dec[mask].tolist(),
-                            jd[mask].tolist(),
-                            ra_s[mask].tolist(),
-                            dec_s[mask].tolist(),
-                        ]
-                    ),
+                    np.vstack([
+                        ph[mask].tolist(),
+                        ra[mask].tolist(),
+                        dec[mask].tolist(),
+                        jd[mask].tolist(),
+                        ra_s[mask].tolist(),
+                        dec_s[mask].tolist(),
+                    ]),
                     params_per_band[index][0],
                     params_per_band[index][1],
                     params_per_band[index][2],
@@ -1349,15 +1345,13 @@ def fit_sfhg1g2(
         outdic = {"fit": 1, "status": -2}
         return outdic
 
-    pdf = pd.DataFrame(
-        {
-            "i:magpsf_red": magpsf_red,
-            "i:sigmapsf": sigmapsf,
-            "Phase": phase,
-            "i:jd": jds,
-            "i:fid": filters,
-        }
-    )
+    pdf = pd.DataFrame({
+        "i:magpsf_red": magpsf_red,
+        "i:sigmapsf": sigmapsf,
+        "Phase": phase,
+        "i:jd": jds,
+        "i:fid": filters,
+    })
     pdf = pdf.sort_values("i:jd")
 
     # Get oppositions


### PR DESCRIPTION
Added a `func_sshg1g2_terminator` function, similar to `func_sshg1g2` or `func_sfhg1g2`, computing the absolute magnitude according to  Ostro & Connelly (1984) and modified related functions to implement the model optionally.