### PR TITLE
[SSO] Performances

### DIFF
--- a/fink_utils/sso/cleaning.py
+++ b/fink_utils/sso/cleaning.py
@@ -189,7 +189,6 @@ def iterative_cleaning(
                     phi_funcs[0][mask],
                     phi_funcs[1][mask],
                     phi_funcs[2][mask],
-                    np.radians(phase_angle_inl[mask]),
                     np.radians(ra_inl[mask]),
                     np.radians(dec_inl[mask]),
                 ],

--- a/fink_utils/sso/cleaning.py
+++ b/fink_utils/sso/cleaning.py
@@ -18,6 +18,7 @@ import numpy as np
 from scipy.stats import gaussian_kde
 
 from fink_utils.sso.spins import estimate_sso_params, func_shg1g2
+from sbpy.photometry import HG1G2
 
 from fink_utils.tester import regular_unit_tests
 
@@ -163,6 +164,12 @@ def iterative_cleaning(
     rejected_mask_total = np.zeros(len(data), dtype=bool)
 
     for k in range(11):
+        # Need to recompute it as length changes iteratively
+        phi_funcs = [
+            HG1G2._phi1(np.radians(phase_angle_inl)),
+            HG1G2._phi2(np.radians(phase_angle_inl)),
+            HG1G2._phi3(np.radians(phase_angle_inl)),
+        ]
         shgg_params = estimate_sso_params(
             mag_red_inl,
             sigma_inl,
@@ -179,6 +186,9 @@ def iterative_cleaning(
 
             pts = func_shg1g2(
                 [
+                    phi_funcs[0][mask],
+                    phi_funcs[1][mask],
+                    phi_funcs[2][mask],
                     np.radians(phase_angle_inl[mask]),
                     np.radians(ra_inl[mask]),
                     np.radians(dec_inl[mask]),

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 AstroLab Software
+# Copyright 2022-2026 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,9 @@ import astropy.units as u
 from fink_utils.sso.utils import estimate_axes_ratio
 from fink_utils.sso.utils import get_opposition, split_dataframe_per_apparition
 from fink_utils.tester import regular_unit_tests
+from line_profiler import profile
+
+from sbpy.photometry import HG, HG1G2, HG12_Pen16
 
 # Phase parameter global bounds
 GMIN = -0.429
@@ -117,7 +120,7 @@ def split_quantity_by_filter(list_of_filters, ordered_vector):
     return np.array_split(ordered_vector, np.cumsum(split_at))
 
 
-def func_hg(ph, h, g):
+def func_hg(phi1, phi2, h, g):
     """Return f(H, G) part of the lightcurve in mag space
 
     Parameters
@@ -134,16 +137,14 @@ def func_hg(ph, h, g):
     out: array of floats
         H - 2.5 log(f(G))
     """
-    from sbpy.photometry import HG
-
     # Standard G part
-    func1 = (1 - g) * HG._hgphi(ph, 1) + g * HG._hgphi(ph, 2)
+    func1 = (1 - g) * phi1 + g * phi2
     func1 = -2.5 * np.log10(func1)
 
     return h + func1
 
 
-def func_hg12(ph, h, g12):
+def func_hg12(phi1, phi2, phi3, h, g12):
     """Return f(H, G) part of the lightcurve in mag space
 
     Parameters
@@ -160,20 +161,13 @@ def func_hg12(ph, h, g12):
     out: array of floats
         H - 2.5 log(f(G12))
     """
-    from sbpy.photometry import HG1G2, HG12_Pen16
-
-    # Standard G1G2 part
     g1 = HG12_Pen16._G12_to_G1(g12)
     g2 = HG12_Pen16._G12_to_G2(g12)
-    func1 = (
-        g1 * HG1G2._phi1(ph) + g2 * HG1G2._phi2(ph) + (1 - g1 - g2) * HG1G2._phi3(ph)
-    )
-    func1 = -2.5 * np.log10(func1)
-
-    return h + func1
+    return func_hg1g2(phi1, phi2, phi3, h, g1, g2)
 
 
-def func_hg1g2(ph, h, g1, g2):
+@profile
+def func_hg1g2(phi1, phi2, phi3, h, g1, g2):
     """Return f(H, G1, G2) part of the lightcurve in mag space
 
     Parameters
@@ -192,12 +186,8 @@ def func_hg1g2(ph, h, g1, g2):
     out: array of floats
         H - 2.5 log(f(G1G2))
     """
-    from sbpy.photometry import HG1G2
-
     # Standard G1G2 part
-    func1 = (
-        g1 * HG1G2._phi1(ph) + g2 * HG1G2._phi2(ph) + (1 - g1 - g2) * HG1G2._phi3(ph)
-    )
+    func1 = g1 * phi1 + g2 * phi2 + (1 - g1 - g2) * phi3
     func1 = -2.5 * np.log10(func1)
 
     return h + func1
@@ -208,7 +198,7 @@ def func_shg1g2(pha, h, g1, g2, R, alpha0, delta0):
 
     Parameters
     ----------
-    pha: array-like [3, N]
+    pha: array-like [5, N]
         List containing [phase angle in radians, RA in radians, Dec in radians]
     h: float
         Absolute magnitude in mag
@@ -228,12 +218,14 @@ def func_shg1g2(pha, h, g1, g2, R, alpha0, delta0):
     out: array of floats
         H - 2.5 log(f(G1G2)) - 2.5 log(f(R, spin))
     """
-    ph = pha[0]
-    ra = pha[1]
-    dec = pha[2]
+    phi1 = pha[0]
+    phi2 = pha[1]
+    phi3 = pha[2]
+    ra = pha[3]
+    dec = pha[4]
 
     # Standard HG1G2 part: h + f(alpha, G1, G2)
-    func1 = func_hg1g2(ph, h, g1, g2)
+    func1 = func_hg1g2(phi1, phi2, phi3, h, g1, g2)
 
     # Spin part
     geo = cos_aspect_angle(ra, dec, alpha0, delta0)
@@ -1515,16 +1507,32 @@ def build_eqs(x, filters, ph, rhs, func=None, remap=False, model=None):
 
     params_per_band = np.reshape(params, (len(filternames), int(nparams)))
     eqs = []
+
     for index, filtername in enumerate(filternames):
         mask = filters == filtername
-
-        myfunc = (
-            func(
-                ph[mask],
+        if model == "HG1G2":
+            lhs = func(
+                HG1G2._phi1(ph[mask]),
+                HG1G2._phi2(ph[mask]),
+                HG1G2._phi3(ph[mask]),
                 *params_per_band[index],
             )
-            - rhs[mask]
-        )
+        elif model == "HG12":
+            lhs = func(
+                HG1G2._phi1(ph[mask]),
+                HG1G2._phi2(ph[mask]),
+                HG1G2._phi3(ph[mask]),
+                *params_per_band[index],
+            )
+        elif model == "HG":
+            lhs = func(
+                HG._hgphi(ph[mask], 1),
+                HG._hgphi(ph[mask], 2),
+                *params_per_band[index],
+            )
+        mask = filters == filtername
+
+        myfunc = lhs - rhs[mask]
 
         eqs = np.concatenate((eqs, myfunc))
 
@@ -1586,9 +1594,20 @@ def build_eqs_for_spins(x, filters, ph, ra, dec, rhs, remap=False):
     for index, filtername in enumerate(filternames):
         mask = filters == filtername
 
+        # Pre-compute phi functions for HG1G2
+        phi1 = HG1G2._phi1(ph[mask])
+        phi2 = HG1G2._phi2(ph[mask])
+        phi3 = HG1G2._phi3(ph[mask])
+
         myfunc = (
             func_shg1g2(
-                np.vstack([ph[mask].tolist(), ra[mask].tolist(), dec[mask].tolist()]),
+                np.vstack([
+                    phi1.tolist(),
+                    phi2.tolist(),
+                    phi3.tolist(),
+                    ra[mask].tolist(),
+                    dec[mask].tolist(),
+                ]),
                 params_per_band[index][0],
                 params_per_band[index][1],
                 params_per_band[index][2],
@@ -1893,6 +1912,7 @@ def estimate_sso_params(
     ...    model='HG',
     ...    normalise_to_V=False, remap=True)
     >>> assert len(hg) == 26, "Found {} parameters: {}".format(len(hg), hg)
+    >>> assert np.isclose(hg['chi2red'], 108.12, rtol=1e-3), hg
 
     >>> hg12 = estimate_sso_params(
     ...    pdf['i:magpsf_red'].values,
@@ -1904,6 +1924,7 @@ def estimate_sso_params(
     ...    model='HG12',
     ...    normalise_to_V=False, remap=True)
     >>> assert len(hg12) == 26, "Found {} parameters: {}".format(len(hg12), hg12)
+    >>> assert np.isclose(hg12['chi2red'], 99.50, rtol=1e-3), hg12
 
     >>> hg1g2 = estimate_sso_params(
     ...    pdf['i:magpsf_red'].values,
@@ -1915,6 +1936,7 @@ def estimate_sso_params(
     ...    model='HG1G2',
     ...    normalise_to_V=False, remap=True)
     >>> assert len(hg1g2) == 30, "Found {} parameters: {}".format(len(hg1g2), hg1g2)
+    >>> assert np.isclose(hg1g2['chi2red'], 99.24, rtol=1e-3), hg1g2
 
     >>> shg1g2 = estimate_sso_params(
     ...    pdf['i:magpsf_red'].values,
@@ -1926,6 +1948,7 @@ def estimate_sso_params(
     ...    model='SHG1G2',
     ...    normalise_to_V=False, remap=True)
     >>> assert len(shg1g2) == 41, "Found {} parameters: {}".format(len(shg1g2), shg1g2)
+    >>> assert np.isclose(shg1g2['chi2red'], 6.281, rtol=1e-3), shg1g2
 
     # SOCCA uses asteroid_spinprops
     # >>> base_kwargs = dict(use_angles=True, use_filter_dependent=True, use_phase=True, use_shape=True,)
@@ -2017,6 +2040,7 @@ def estimate_sso_params(
     return outdic
 
 
+@profile
 def fit_legacy_models(
     magpsf_red, sigmapsf, phase, filters, model, p0=None, bounds=None, remap=False
 ):

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -221,17 +221,11 @@ def func_shg1g2(pha, h, g1, g2, R, alpha0, delta0):
     out: array of floats
         H - 2.5 log(f(G1G2)) - 2.5 log(f(R, spin))
     """
-    phi1 = pha[0]
-    phi2 = pha[1]
-    phi3 = pha[2]
-    ra = pha[3]
-    dec = pha[4]
-
     # Standard HG1G2 part: h + f(alpha, G1, G2)
-    func1 = func_hg1g2(phi1, phi2, phi3, h, g1, g2)
+    func1 = func_hg1g2(pha[0], pha[1], pha[2], h, g1, g2)
 
     # Spin part
-    geo = cos_aspect_angle(ra, dec, alpha0, delta0)
+    geo = cos_aspect_angle(pha[3], pha[4], alpha0, delta0)
     func2 = 1 - (1 - R) * np.abs(geo)
     func2 = 2.5 * np.log10(func2)
 
@@ -1515,23 +1509,26 @@ def build_eqs(x, filters, ph, rhs, func=None, remap=False, model=None):
     for index, filtername in enumerate(filternames):
         mask = filters == filtername
         if model == "HG1G2":
+            phi1, phi2, phi3 = ph
             lhs = func(
-                HG1G2._phi1(ph[mask]),
-                HG1G2._phi2(ph[mask]),
-                HG1G2._phi3(ph[mask]),
+                phi1[mask],
+                phi2[mask],
+                phi3[mask],
                 *params_per_band[index],
             )
         elif model == "HG12":
+            phi1, phi2, phi3 = ph
             lhs = func(
-                HG1G2._phi1(ph[mask]),
-                HG1G2._phi2(ph[mask]),
-                HG1G2._phi3(ph[mask]),
+                phi1[mask],
+                phi2[mask],
+                phi3[mask],
                 *params_per_band[index],
             )
         elif model == "HG":
+            phi1, phi2 = ph
             lhs = func(
-                HG._hgphi(ph[mask], 1),
-                HG._hgphi(ph[mask], 2),
+                phi1[mask],
+                phi2[mask],
                 *params_per_band[index],
             )
         mask = filters == filtername
@@ -1594,25 +1591,23 @@ def build_eqs_for_spins(x, filters, ph, ra, dec, rhs, remap=False):
     nparams = len(params) / len(filternames)
     assert int(nparams) == nparams, "You need to input all parameters for all bands"
 
+    # Get pre-computed phi functions
+    phi1, phi2, phi3 = ph
+
     params_per_band = np.reshape(params, (len(filternames), int(nparams)))
     eqs = []
     for index, filtername in enumerate(filternames):
         mask = filters == filtername
 
-        # Pre-compute phi functions for HG1G2
-        phi1 = HG1G2._phi1(ph[mask])
-        phi2 = HG1G2._phi2(ph[mask])
-        phi3 = HG1G2._phi3(ph[mask])
-
         myfunc = (
             func_shg1g2(
-                np.vstack([
-                    phi1.tolist(),
-                    phi2.tolist(),
-                    phi3.tolist(),
-                    ra[mask].tolist(),
-                    dec[mask].tolist(),
-                ]),
+                [
+                    phi1[mask],
+                    phi2[mask],
+                    phi3[mask],
+                    ra[mask],
+                    dec[mask],
+                ],
                 params_per_band[index][0],
                 params_per_band[index][1],
                 params_per_band[index][2],
@@ -1728,12 +1723,12 @@ def build_eqs_for_spin_shape(
 
             myfunc = (
                 func_socca(
-                    np.vstack([
-                        ph[mask].tolist(),
-                        ra[mask].tolist(),
-                        dec[mask].tolist(),
-                        jd[mask].tolist(),
-                    ]),
+                    [
+                        ph[mask],
+                        ra[mask],
+                        dec[mask],
+                        jd[mask],
+                    ],
                     params_per_band[index][0],
                     params_per_band[index][1],
                     params_per_band[index][2],
@@ -2098,6 +2093,7 @@ def fit_legacy_models(
         assert len(bounds[0]) == nparams, (
             "You need to specify bounds on all (H, G1, G2) parameters"
         )
+        phi_funcs = [HG1G2._phi1(phase), HG1G2._phi2(phase), HG1G2._phi3(phase)]
     elif model == "HG12":
         func = func_hg12
         nparams = 2
@@ -2118,6 +2114,7 @@ def fit_legacy_models(
         assert len(bounds[0]) == nparams, (
             "You need to specify bounds on all (H, G12) parameters"
         )
+        phi_funcs = [HG1G2._phi1(phase), HG1G2._phi2(phase), HG1G2._phi3(phase)]
     elif model == "HG":
         func = func_hg
         nparams = 2
@@ -2137,6 +2134,7 @@ def fit_legacy_models(
         assert len(bounds[0]) == nparams, (
             "You need to specify bounds on all (H, G) parameters"
         )
+        phi_funcs = [HG._hgphi(phase, 1), HG._hgphi(phase, 2)]
 
     ufilters = np.unique(filters)
 
@@ -2165,7 +2163,7 @@ def fit_legacy_models(
             bounds=(lower_bounds, upper_bounds),
             jac="2-point",
             loss="soft_l1",
-            args=(filters, phase, magpsf_red, func, remap, model),
+            args=(filters, phi_funcs, magpsf_red, func, remap, model),
         )
     except RuntimeError:
         outdic = {"fit": 3, "status": -2}
@@ -2361,6 +2359,7 @@ def fit_sfhg1g2(
     return outdics
 
 
+@profile
 def fit_spin(
     magpsf_red,
     sigmapsf,
@@ -2512,7 +2511,14 @@ def fit_spin(
     try:
         if model == "SHG1G2":
             func = build_eqs_for_spins
-            args = (filters, phase, ra, dec, magpsf_red, remap)
+            args = (
+                filters,
+                [HG1G2._phi1(phase), HG1G2._phi2(phase), HG1G2._phi3(phase)],
+                ra,
+                dec,
+                magpsf_red,
+                remap,
+            )
         elif model == "SOCCA":
             func = build_eqs_for_spin_shape
             if not terminator:

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -349,10 +349,12 @@ def func_socca(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0):
     out: array of floats
         H - 2.5 log(f(G1G2)) - 2.5 log(f(spin, shape))
     """
-    ph = pha[0]
-    ra = pha[1]
-    dec = pha[2]
-    ep = pha[3]
+    phi1 = pha[0]
+    phi2 = pha[1]
+    phi3 = pha[2]
+    ra = pha[3]
+    dec = pha[4]
+    ep = pha[5]
 
     # TBD: For the time being, we fix the reference time
     # Time( '2022-01-01T00:00:00', format='isot', scale='utc').jd
@@ -361,7 +363,7 @@ def func_socca(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0):
     t0 = 2459580.5
 
     # Standard HG1G2 part: h + f(alpha, G1, G2)
-    func1 = func_hg1g2(ph, h, g1, g2)
+    func1 = func_hg1g2(phi1, phi2, phi3, h, g1, g2)
 
     # Spin part
     cos_aspect = cos_aspect_angle(ra, dec, alpha0, delta0)
@@ -470,12 +472,14 @@ def func_socca_terminator(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0
         H - 2.5 log(f(G1G2)) - 2.5 log(f(spin, shape))
         Similar to the SOCCA model, but including the correction for the non-illuminated part of the asteroid
     """
-    ph = pha[0]
-    ra = pha[1]
-    dec = pha[2]
-    ep = pha[3]
-    ra_s = pha[4]
-    dec_s = pha[5]
+    phi1 = pha[0]
+    phi2 = pha[1]
+    phi3 = pha[2]
+    ra = pha[3]
+    dec = pha[4]
+    ep = pha[5]
+    ra_s = pha[6]
+    dec_s = pha[7]
 
     # TBD: For the time being, we fix the reference time
     # Time( '2022-01-01T00:00:00', format='isot', scale='utc').jd
@@ -484,7 +488,7 @@ def func_socca_terminator(pha, h, g1, g2, alpha0, delta0, period, a_b, a_c, phi0
     t0 = 2459580.5
 
     # Standard HG1G2 part: h + f(alpha, G1, G2)
-    func1 = func_hg1g2(ph, h, g1, g2)
+    func1 = func_hg1g2(phi1, phi2, phi3, h, g1, g2)
 
     # Rotation
     W = rotation_phase(ep, phi0, 2 * np.pi / period, t0)
@@ -1715,6 +1719,9 @@ def build_eqs_for_spin_shape(
     nparams = len(params) / len(filternames)
     assert int(nparams) == nparams, "You need to input all parameters for all bands"
 
+    # Get pre-computed phi functions
+    phi1, phi2, phi3 = ph
+
     params_per_band = np.reshape(params, (len(filternames), int(nparams)))
     eqs = []
     if not terminator:
@@ -1724,7 +1731,9 @@ def build_eqs_for_spin_shape(
             myfunc = (
                 func_socca(
                     [
-                        ph[mask],
+                        phi1[mask],
+                        phi2[mask],
+                        phi3[mask],
                         ra[mask],
                         dec[mask],
                         jd[mask],
@@ -1749,14 +1758,16 @@ def build_eqs_for_spin_shape(
 
             myfunc = (
                 func_socca_terminator(
-                    np.vstack([
-                        ph[mask].tolist(),
-                        ra[mask].tolist(),
-                        dec[mask].tolist(),
-                        jd[mask].tolist(),
-                        ra_s[mask].tolist(),
-                        dec_s[mask].tolist(),
-                    ]),
+                    [
+                        phi1[mask],
+                        phi2[mask],
+                        phi3[mask],
+                        ra[mask],
+                        dec[mask],
+                        jd[mask],
+                        ra_s[mask],
+                        dec_s[mask],
+                    ],
                     params_per_band[index][0],
                     params_per_band[index][1],
                     params_per_band[index][2],
@@ -1951,20 +1962,6 @@ def estimate_sso_params(
     ...    normalise_to_V=False, remap=True)
     >>> assert len(shg1g2) == 41, "Found {} parameters: {}".format(len(shg1g2), shg1g2)
     >>> assert np.isclose(shg1g2['chi2red'], 6.281, rtol=1e-3), shg1g2
-
-    # SOCCA uses asteroid_spinprops
-    # >>> base_kwargs = dict(use_angles=True, use_filter_dependent=True, use_phase=True, use_shape=True,)
-    # >>> socca = estimate_sso_params(
-    # ...    pdf['i:magpsf_red'].values,
-    # ...    pdf['i:sigmapsf'].values,
-    # ...    np.deg2rad(pdf['Phase'].values),
-    # ...    pdf['i:fid'].values,
-    # ...    np.deg2rad(pdf['i:ra'].values),
-    # ...    np.deg2rad(pdf['i:dec'].values),
-    # ...    pdf['i:jd'].values,
-    # ...    model='SOCCA',
-    # ...    normalise_to_V=False, remap=True, remap_kwargs=base_kwargs)
-    # >>> assert len(socca) == 45, "Found {} parameters: {}".format(len(socca), socca)
 
     # You can also combine data into single V band
     >>> shg1g2 = estimate_sso_params(

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -120,6 +120,7 @@ def split_quantity_by_filter(list_of_filters, ordered_vector):
     return np.array_split(ordered_vector, np.cumsum(split_at))
 
 
+@profile
 def func_hg(phi1, phi2, h, g):
     """Return f(H, G) part of the lightcurve in mag space
 
@@ -144,6 +145,7 @@ def func_hg(phi1, phi2, h, g):
     return h + func1
 
 
+@profile
 def func_hg12(phi1, phi2, phi3, h, g12):
     """Return f(H, G) part of the lightcurve in mag space
 
@@ -193,6 +195,7 @@ def func_hg1g2(phi1, phi2, phi3, h, g1, g2):
     return h + func1
 
 
+@profile
 def func_shg1g2(pha, h, g1, g2, R, alpha0, delta0):
     """Return f(H, G1, G2, R, alpha0, delta0) part of the lightcurve in mag space
 
@@ -1451,6 +1454,7 @@ def parameter_remapping(
     return np.array(out)
 
 
+@profile
 def build_eqs(x, filters, ph, rhs, func=None, remap=False, model=None):
     """Build the system of equations to solve using the HG, HG12, or HG1G2 model
 
@@ -1539,6 +1543,7 @@ def build_eqs(x, filters, ph, rhs, func=None, remap=False, model=None):
     return np.ravel(eqs)
 
 
+@profile
 def build_eqs_for_spins(x, filters, ph, ra, dec, rhs, remap=False):
     """Build the system of equations to solve using the HG1G2 + spin model
 
@@ -1623,6 +1628,7 @@ def build_eqs_for_spins(x, filters, ph, ra, dec, rhs, remap=False):
     return np.ravel(eqs)
 
 
+@profile
 def build_eqs_for_spin_shape(
     x,
     filters,
@@ -1774,6 +1780,7 @@ def build_eqs_for_spin_shape(
     return np.ravel(eqs)
 
 
+@profile
 def estimate_sso_params(
     magpsf_red,
     sigmapsf,

--- a/fink_utils/sso/spins.py
+++ b/fink_utils/sso/spins.py
@@ -2521,7 +2521,7 @@ def fit_spin(
             if not terminator:
                 args = (
                     filters,
-                    phase,
+                    [HG1G2._phi1(phase), HG1G2._phi2(phase), HG1G2._phi3(phase)],
                     ra,
                     dec,
                     jd,
@@ -2534,7 +2534,7 @@ def fit_spin(
             else:
                 args = (
                     filters,
-                    phase,
+                    [HG1G2._phi1(phase), HG1G2._phi2(phase), HG1G2._phi3(phase)],
                     ra,
                     dec,
                     jd,


### PR DESCRIPTION
## SHG1G2

Code in `profiling.py`:

```python
import io
import requests
import pandas as pd
import numpy as np

from fink_utils.sso.spins import estimate_sso_params

r = requests.post(
    "https://api.ztf.fink-portal.org/api/v1/sso",
    json={"n_or_d": "223", "withEphem": True, "output-format": "json"},
)

pdf = pd.read_json(io.BytesIO(r.content))

shg1g2 = estimate_sso_params(
    pdf["i:magpsf_red"].values,
    pdf["i:sigmapsf"].values,
    np.deg2rad(pdf["Phase"].values),
    pdf["i:fid"].values,
    np.deg2rad(pdf["i:ra"].values),
    np.deg2rad(pdf["i:dec"].values),
    model="SHG1G2",
    normalise_to_V=False,
    remap=True,
)
```

Run with:

```bash
kernprof -l profiling.py
python -m line_profiler -rmt profiling.py.lprof
```


```bash
# main
  0.56 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:175 - func_hg1g2
  0.57 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:205 - func_shg1g2
  0.63 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1533 - build_eqs_for_spins
  0.66 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:2332 - fit_spin
  0.66 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1757 - estimate_sso_params
```
versus

```bash
# branch issue/264/perf
  0.01 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:171 - func_hg1g2
  0.02 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:198 - func_shg1g2
  0.05 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1549 - build_eqs_for_spins
  0.08 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:2368 - fit_spin
  0.08 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1784 - estimate_sso_params
```

Test suite has been improved to further validate code change.

## SOCCA

I use the following script:

```python
import io
import requests
import pandas as pd
import numpy as np
from astropy.coordinates import SkyCoord
import astropy.units as u

from fink_utils.sso.utils import compute_light_travel_correction
from fink_utils.sso.cleaning import dxy_cleaning, iterative_cleaning

from asteroid_spinprops.ssolib import modelfit

ZTF_PIX_SIZE_ARCSEC = 1.0
FILTERING = False

SSOID = "2000 HR66"
r = requests.post(
    "https://api.ztf.fink-portal.org/api/v1/sso",
    json={"n_or_d": SSOID, "withEphem": True, "output-format": "json"},
)

pdf = pd.read_json(io.BytesIO(r.content))

jd_lt = compute_light_travel_correction(
    pdf["i:jd"],
    pdf["Dobs"],
)

# dx, dy from deviation to ephemerides
position = SkyCoord(ra=pdf["i:ra"], dec=pdf["i:dec"], unit="deg")
ephemeride = SkyCoord(ra=pdf["RA"], dec=pdf["DEC"], unit="deg")

dra, ddec = position.spherical_offsets_to(ephemeride)

dx = dra.to(u.arcsec) * ZTF_PIX_SIZE_ARCSEC
dy = ddec.to(u.arcsec) * ZTF_PIX_SIZE_ARCSEC


pdf = pd.DataFrame({
    "cmred": pdf["i:magpsf_red"],
    "csigmapsf": pdf["i:sigmapsf"],
    "Phase": pdf["Phase"],
    "cfid": pdf["i:fid"],
    "ra": pdf["i:ra"],
    "dec": pdf["i:dec"],
    "cjd": jd_lt,
    "i:raephem": pdf["RA"],
    "i:decephem": pdf["DEC"],
    "ra_s": pdf["RA_h"],
    "dec_s": pdf["DEC_h"],
    "cdx": dx,
    "cdy": dy,
    "Dhelio": pdf["Dhelio"],
})
pdf = pdf.sort_values("cjd")

if FILTERING:
    pdf["dxy"] = np.sqrt(pdf["cdx"] ** 2 + pdf["cdy"] ** 2)
    pdf, _ = dxy_cleaning(
        pdf,
        pdf["dxy"],
        pdf["cmred"],
        threshold=0.95,
    )

    pdf, _ = iterative_cleaning(
        pdf,
        pdf["cmred"],
        pdf["csigmapsf"],
        pdf["Phase"],
        pdf["cfid"],
        pdf["ra"],
        pdf["dec"],
    )

# Wrap columns inplace
pdf_transposed = pd.DataFrame({
    colname: [pdf[colname].to_numpy()] for colname in pdf.columns
})

base_kwargs = dict(
    use_angles=True,
    use_filter_dependent=True,
    use_phase=True,
    use_shape=True,
)

current_kwargs = base_kwargs.copy()

outdic = modelfit.get_fit_params(
    data=pdf_transposed,
    flavor="SOCCA",
    shg1g2_constrained=True,
    period_blind=True,
    pole_blind=False,
    period_in=None,
    period_quality_flag=True,
    terminator=True,
    time_me=True,
    remap=True,
    remap_kwargs=current_kwargs,
)
```

Run with:

```bash
kernprof -l profiling_socca.py
python -m line_profiler -rmt profiling.py.lprof
```

and here are profiling results (I checked parameter values are the same):

```
# main
  0.00 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:146 - func_hg12
  0.64 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1536 - build_eqs_for_spins
  1.71 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:207 - func_shg1g2
  9.19 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1610 - build_eqs_for_spin_shape
 10.77 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:2338 - fit_spin
 10.77 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1762 - estimate_sso_params
 11.62 seconds - /home/peloton/codes/asteroid-spinprops/asteroid_spinprops/ssolib/periodest.py:34 - get_period_estimate
 11.67 seconds - /home/peloton/codes/asteroid-spinprops/asteroid_spinprops/ssolib/periodest.py:329 - perform_residual_resampling
 26.98 seconds - /home/peloton/codes/asteroid-spinprops/asteroid_spinprops/ssolib/modelfit.py:18 - get_fit_params

# branch issue/264/perf -- speed up from func spins only
  0.02 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1547 - build_eqs_for_spins
  0.09 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:198 - func_shg1g2
  0.17 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:171 - func_hg1g2
  2.59 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1630 - build_eqs_for_spin_shape
  3.49 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:2359 - fit_spin
  3.49 seconds - /home/peloton/codes/fink-utils/fink_utils/sso/spins.py:1789 - estimate_sso_params
 11.59 seconds - /home/peloton/codes/asteroid-spinprops/asteroid_spinprops/ssolib/periodest.py:34 - get_period_estimate
 11.65 seconds - /home/peloton/codes/asteroid-spinprops/asteroid_spinprops/ssolib/periodest.py:329 - perform_residual_resampling
 18.57 seconds - /home/peloton/codes/asteroid-spinprops/asteroid_spinprops/ssolib/modelfit.py:20 - get_fit_params
```

Almost factor of 2 speed-up.

## Cleaning procedure

The results above do not use the cleaning procedure from Odysseas. If I trigger it, I get the following results:

| Cleaning | `rms` | `f_obs` | `Period_class` | `get_fit_params` time |
|----|-------|----------|-------------------|--------------------------------|
| True  | 0.079 | 10.871 | 0 | 33 sec |
| False  | 0.091 | 9.869| 0 | 17 sec |

Values are close, but `get_fit_params` struggles a lot to converge if I get supposedly cleaned values! Note that I am using ZTF only, so maybe the cleaning procedure decimates too much the lightcurve, hence the fits struggles (for `2000 HR66` used here, we have initially 21 measurements in g and 46 measurements in r). I tried on `Wallenquist` (173 in g, 228 in r): the timings are the same with or without cleaning, but the rms is smaller with cleaning (_ouf !_):

| Cleaning | `rms` | `f_obs` | `Period_class` | `get_fit_params` time |
|----|-------|----------|-------------------|--------------------------------|
| True  | 0.076 | 8.715 | 0 | 39 sec |
| False  | 0.080 | 8.715| 0 | 38 sec |

So we should keep an eye on undersampled lightcurves which might be artificially degraded by cleaning procedures (which are relative and not absolute).

## Further speed-up

At this point, one of the limiting function was `model.autopower` which was called 50+ times. One of the parameter of that function is `samples_per_peak (default is 5)`. If I modify this parameter, I get (results using `2000 HR66` and cleaning procedures):

| `samples_per_peak` | `rms` | `f_obs` | `Period_class` | `get_fit_params` time |
|----|-------|----------|-------------------|--------------------------------|
| 5 (default)  | 0.079 | 10.871 | 0 | 33 sec |
| 3  | 0.087 | 9.869 | 0 | 24 sec |
| 2  | 0.079 | 10.872 | 1 | 12 sec |

Note that the case for 5 and 2 samples per peak give the same period, but `Period_class` is different (and there is a factor 2 in terms of performance!). Weird?

Note that if I use no cleaning + `samples_per_peak = 2`, I get the same result than with cleaning, which might indicates that `samples_per_peak = 5` is overkill. And indeed, using a more densely sampled lightcurve (`Wallenquist`, 173 in g, 228 in r):

| `samples_per_peak` | `rms` | `f_obs` | `Period_class` | `get_fit_params` time |
|----|-------|----------|-------------------|--------------------------------|
| 5 (default)  | 0.076 | 8.715 | 0 | 41 sec |
| 2  | 0.076 | 8.715 | 0 | 18 sec |

Same results, but 2x faster with 2 samples per peak.