### PR TITLE
Filter out observations before April 2026 for the Rubin SSOFT

### DIFF
--- a/fink_utils/sso/ssoft.py
+++ b/fink_utils/sso/ssoft.py
@@ -756,6 +756,11 @@ def aggregate_rubin_sso_data(
 
     df = spark.read.format("parquet").option("basePath", prefix_path).load(path)
 
+    if year is None:
+        # Observations before April 2026 had no topoRange/helioRange
+        mjd_start = Time("2026-04-01").tai.mjd
+        df = df.filter(df["diaSource.midpointMjdTai"] >= mjd_start)
+
     if month is None and stop_previous_month:
         prevdate = retrieve_last_date_of_previous_month(datetime.datetime.today())
         # take the last hour of the last day


### PR DESCRIPTION
Closes #277

Note that we impose the filter only when recomputing all SSOFT values. For monthly runs, no need to filter out as we will never start that early (we first compute all values in 2026, and then keep going month by month).
